### PR TITLE
Fix support for snapshot and source Composer runs

### DIFF
--- a/src/Utils/Version.php
+++ b/src/Utils/Version.php
@@ -32,7 +32,8 @@ class Version
      */
     public function findBestCandidate(Composer $composer, string $packageName, RepositoryInterface $repository): ?PackageInterface
     {
-        $composerMajorVersion = (int)explode('.', $composer::VERSION)[0];
+        $composerVersion = method_exists('Composer\Composer', 'getVersion') ? Composer::getVersion() : Composer::VERSION;
+        $composerMajorVersion = (int)explode('.', $composerVersion)[0];
 
         if ($composerMajorVersion === 1) {
             $bestCandidate = $this->findBestCandidateComposer1($composer, $packageName, $repository);


### PR DESCRIPTION
Composer::getVersion() should be preferred, but it's "only" available since [Composer 1.8.5](https://github.com/composer/composer/commit/427116749558f99e4c04ffa3fe358ebfd74d2fa5), so I left a fallback on ::VERSION for safety.

Without this, if you use a Composer snapshot you get a commit hash in VERSION and this detection fails to detect anything.
